### PR TITLE
Read input files with UTF_8 encoding instead of platform default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+**For the title of this PR:** A succinct and user-oriented title. It should not contain any code and be use the present tense. 
+
+## What is the goal of this PR?
+
+{ Describe the goal and new behaviour of this PR from the user's point of view, and reference related GitHub issues. }
+
+## What are the changes implemented in this PR?
+
+{ Explain what you implemented, why your changes are the best way to achieve the goal(s) above. 
+
+This would allow the reviewer to understand your intentions in the code much better. Please reference the GitHub issues to be automatically closed, such like 'closes #number'. }

--- a/src/main/java/util/Util.java
+++ b/src/main/java/util/Util.java
@@ -28,11 +28,14 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
 import static io.FileToInputStream.getInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Util {
     private static final Logger appLogger = LogManager.getLogger("com.bayer.dt.tdl.loader");
@@ -71,7 +74,7 @@ public class Util {
     public static String loadSchemaFromFile(String schemaPath) {
         String schema = "";
         try {
-            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(schemaPath)));
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(schemaPath), UTF_8));
             StringBuilder sb = new StringBuilder();
             String line = br.readLine();
             while (line != null) {
@@ -88,7 +91,7 @@ public class Util {
     public static BufferedReader newBufferedReader(String filePath) throws FileNotFoundException {
         InputStream is = getInputStream(filePath);
         if (is != null) {
-            return new BufferedReader(new InputStreamReader(is));
+            return new BufferedReader(new InputStreamReader(is, UTF_8));
         } else {
             throw new FileNotFoundException();
         }


### PR DESCRIPTION
## What is the goal of this PR?

Explicitly use UTF-8 as the encoding to read files, instead of allowing Java to pick the platform default which differs per operating system.

## What are the changes implemented in this PR?

Read schema and csv data files using UTF-8 encoding.