### PR TITLE
Reduce logical dependencies on TypeQL toString()

### DIFF
--- a/src/main/java/generator/AppendAttributeGenerator.java
+++ b/src/main/java/generator/AppendAttributeGenerator.java
@@ -114,7 +114,7 @@ public class AppendAttributeGenerator implements Generator {
         if (insert == null) return false;
         if (!insert.toString().contains("isa " + appendConfiguration.getMatch().getType())) return false;
         for (Configuration.Definition.Attribute ownershipThingGetter : appendConfiguration.getMatch().getOwnerships()) {
-            if (!insert.toString().contains(", has " + ownershipThingGetter.getAttribute())) return false;
+            if (!insert.toString().contains("has " + ownershipThingGetter.getAttribute())) return false;
         }
         if (appendConfiguration.getInsert().getRequiredOwnerships() != null) {
             for (Configuration.Definition.Attribute attribute : appendConfiguration.getInsert().getRequiredOwnerships()) {

--- a/src/main/java/generator/RelationGenerator.java
+++ b/src/main/java/generator/RelationGenerator.java
@@ -101,7 +101,7 @@ public class RelationGenerator implements Generator {
                 // ENTITY & RELATION PLAYER BY ATTRIBUTE(s)
                 if (playerType(player).equals("byAttribute")) {
                     ThingVariable.Thing playerMatchStatement = getThingPlayerMatchStatementByAttribute(row, player, playerVar);
-                    if (playerMatchStatement.toString().contains(", has")) {
+                    if (playerMatchStatement.constraints().stream().anyMatch(ThingConstraint::isHas)) {
                         playerMatchStatements.add(playerMatchStatement);
                         playerVars.add(playerVar);
                         roleTypes.add(player.getRole());
@@ -186,7 +186,7 @@ public class RelationGenerator implements Generator {
             //terminating condition - byAttribute player:
             ArrayList<ThingVariable<?>> statements = new ArrayList<>();
             ThingVariable<?> statement = getThingPlayerMatchStatementByAttribute(row, player, playerVar);
-            if (statement != null && statement.toString().contains(", has")) {
+            if (statement != null && statement.constraints().stream().anyMatch(ThingConstraint::isHas)) {
                 statements.add(statement);
             }
             return statements;


### PR DESCRIPTION
## What is the goal of this PR?

As outlined in https://github.com/typedb-osi/typedb-loader/issues/54, a change in TypeQL meant that some of the `toString()` representations have changed. This PR reduces reliance on `toString()` for correctness, though more work needs to be done to eliminate the dependency.

## What are the changes implemented in this PR?

* Fix one `toString()` check that included a comma that no longer exists
* Replace to usages of `toString()` contains checks with operations over the TypeQL query object.