### PR TITLE
Publish to Vaticle OSI maven repository

### DIFF
--- a/.github/workflows/publish_maven.yaml
+++ b/.github/workflows/publish_maven.yaml
@@ -13,4 +13,5 @@ jobs:
       - name: Publish package
         run: gradle publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_VATICLE_OSI_USERNAME: ${{ secrets.REPO_VATICLE_OSI_USERNAME }}
+          REPO_VATICLE_OSI_PASSWORD: ${{ secrets.REPO_VATICLE_OSI_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -119,18 +119,16 @@ A complete tutorial for TypeDB (Grakn) version < 2.0 can be found [on Medium](ht
 
 There is an [example repository](https://github.com/bayer-science-for-a-better-life/grami-example) for your convenience.
 
-## Compatibility
+## Compatibility Table
 
-TypeDB Loader version == 1.0.0 is tested for:
-- [Type DB](https://github.com/vaticle/typedb) == 2.5.0
+| TypeDB Loader  | TypeDB Client Used  | TypeDB          | TypeDB Cluster |
+| :------------: | :-----------------: | :-------------: | :------------: |
+| 1.1.0 to 1.2.0 | 2.8.0               | 2.8.x           / N/A            |
+| 1.0.0          | 2.5.0 to 2.7.1      | 2.5.x to 2.7.x  / N/A            |
+| 0.1.1          | 2.0.0 to 2.5.0      | 2.0.x to 2.4.x  | N/A            |
+| <0.1           | 1.8.0               | 1.8.x           | N/A            |
 
-GraMi (former name) version == 0.1.1 is tested for:
-- [grakn-core](https://github.com/vaticle/typedb) == 2.0.1
-
-Find the Readme for GraMi for grakn == 2.0.x [here](https://github.com/bayer-science-for-a-better-life/grami/blob/XXXXX/README.md)
-
-GraMi version < 0.1.0 is tested for: 
- - [grakn-core](https://github.com/vaticle/typedb) >= 1.8.2
+* [Type DB](https://github.com/vaticle/typedb)
 
 Find the Readme for GraMi for grakn < 2.0 [here](https://github.com/bayer-science-for-a-better-life/grami/blob/b3d6d272c409d6c40254354027b49f90b255e1c3/README.md)
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ There is an [example repository](https://github.com/bayer-science-for-a-better-l
 
 ## Compatibility Table
 
-| TypeDB Loader  | TypeDB Client Used  | TypeDB          | TypeDB Cluster |
-| :------------: | :-----------------: | :-------------: | :------------: |
-| 1.1.0 to 1.2.0 | 2.8.0               | 2.8.x           / N/A            |
-| 1.0.0          | 2.5.0 to 2.7.1      | 2.5.x to 2.7.x  / N/A            |
-| 0.1.1          | 2.0.0 to 2.5.0      | 2.0.x to 2.4.x  | N/A            |
-| <0.1           | 1.8.0               | 1.8.x           | N/A            |
+| TypeDB Loader  | TypeDB Client (internal) | TypeDB          | TypeDB Cluster |
+| :------------: | :---------------------:  | :-------------: | :------------: |
+| 1.1.0 to 1.2.0 | 2.8.0                    | 2.8.x           |  N/A            |
+| 1.0.0          | 2.5.0 to 2.7.1           | 2.5.x to 2.7.x  | N/A            |
+| 0.1.1          | 2.0.0 to 2.5.0           | 2.0.x to 2.4.x  | N/A            |
+| <0.1           | 1.8.0                    | 1.8.x           | N/A            |
 
 * [Type DB](https://github.com/vaticle/typedb)
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ publishing {
     }
     repositories {
         maven {
-            name = "VaticleMaven"
-            url = "https://repo.vaticle.com/repository/maven/"
+            name = "VaticleOSIMaven"
+            url = "https://repo.vaticle.com/repository/osi-maven/"
             credentials {
                 username = System.getenv("REPO_VATICLE_OSI_USERNAME")
                 password = System.getenv("REPO_VATICLE_OSI_PASSWORD")

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ publishing {
             name = "VaticleMaven"
             url = "https://repo.vaticle.com/repository/maven/"
             credentials {
-                username = System.getenv("REPO_VATICLE_OSI_PASSWORD")
-                password = System.getenv("REPO_VATICLE_OSI_USERNAME")
+                username = System.getenv("REPO_VATICLE_OSI_USERNAME")
+                password = System.getenv("REPO_VATICLE_OSI_PASSWORD")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,11 @@ publishing {
     }
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/typedb-osi/typedb-loader"
+            name = "VaticleMaven"
+            url = "https://repo.vaticle.com/repository/maven/"
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = System.getenv("REPO_VATICLE_OSI_PASSWORD")
+                password = System.getenv("REPO_VATICLE_OSI_USERNAME")
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

In order to make the published Maven artifact accessible to any developer, we must remove the usage of Github's maven repository which is not anonymous accessible. Instead, we publish to the Vaticle OSI Maven repository.

## What are the changes implemented in this PR?

* Update `build.gradle` to publish to the Vaticle OSI Maven repository instead of Github's
* Update github action secrets to use the new repo's username/password
* Update the README with a compatibility table outlining versioning information