### PR TITLE
Replace ':' in log file name

### DIFF
--- a/src/main/java/io/FileLogger.java
+++ b/src/main/java/io/FileLogger.java
@@ -32,7 +32,7 @@ public class FileLogger {
     private final String directoryString;
 
     private FileLogger() {
-        DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH:mm:ss").withZone(ZoneId.systemDefault());
+        DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH_mm_ss").withZone(ZoneId.systemDefault());
         File directory = new File(DATE_TIME_FORMATTER.format(new Date().toInstant()));
         this.directoryString = directory.toString();
         if (! directory.exists()){


### PR DESCRIPTION
## What is the goal of this PR?

Issue #59 reports that `:` cannot be used in file names for error logging on Windows. To fix this, we replace `:` with `_` in the log file name.

## What are the changes implemented in this PR?
* Replace `:` with `_` with in the FileLogger for invalid csv lines
