### PR TITLE
Update for typedb 2.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ---
 ---
 
-###   
+###    
 
 [![TypeDB Loader Test](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/testandbuild.yaml/badge.svg)](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/testandbuild.yaml)
 [![TypeDB Loader Build](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/release.yaml/badge.svg)](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/release.yaml)
@@ -153,17 +153,18 @@ To connect to TypeDB Cluster, a set of options is provided:
 
 ## Compatibility Table
 
-Ranges are [inclusive, exclusive).
+Ranges are [inclusive, inclusive].
 
-| TypeDB Loader | TypeDB Client (internal) |     TypeDB      | TypeDB Cluster  |
-|:-------------:|:------------------------:|:---------------:|:---------------:|
-|     1.7.0     |          2.18.1          |    2.18.x -     |    2.18.x -     |
-|     1.6.0     |          2.14.2          | 2.14.x - 2.17.x | 2.14.x - 2.16.x |
-| 1.2.0 - 1.6.0 |      2.8.0 - 2.14.0      | 2.8.0 - 2.14.0  |       N/A       |
-| 1.1.0 - 1.2.0 |          2.8.0           |      2.8.x      |       N/A       |
-|     1.0.0     |      2.5.0 - 2.7.1       |  2.5.x - 2.7.x  |       N/A       |
-|     0.1.1     |      2.0.0 - 2.5.0       |  2.0.x - 2.4.x  |       N/A       |
-|     <0.1      |          1.8.0           |      1.8.x      |       N/A       |
+| TypeDB Loader | TypeDB Driver (internal) |     TypeDB      | TypeDB Cluster  |
+|:-------------:|:----------------------:|:---------------:|:---------------:|
+|     1.8.0     |        2.24.15         |    2.24.x -     |    2.24.x -     |
+|     1.7.0     |         2.18.1         |  2.18.x 2.23.x  |  2.18.x 2.23.x  |
+|     1.6.0     |         2.14.2         | 2.14.x - 2.17.x | 2.14.x - 2.16.x |
+| 1.2.0 - 1.5.x |     2.8.0 - 2.14.0     | 2.8.0 - 2.14.0  |       N/A       |
+| 1.1.0 - 1.1.x |         2.8.0          |      2.8.x      |       N/A       |
+|     1.0.0     |     2.5.0 - 2.7.1      |  2.5.x - 2.7.x  |       N/A       |
+|     0.1.1     |     2.0.0 - 2.4.x      |  2.0.x - 2.4.x  |       N/A       |
+|     <0.1      |         1.8.0          |      1.8.x      |       N/A       |
 
 * [Type DB](https://github.com/vaticle/typedb)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ---
 ---
 
-###    
+###     
 
 [![TypeDB Loader Test](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/testandbuild.yaml/badge.svg)](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/testandbuild.yaml)
 [![TypeDB Loader Build](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/release.yaml/badge.svg)](https://github.com/bayer-science-for-a-better-life/grami/actions/workflows/release.yaml)
@@ -156,15 +156,16 @@ To connect to TypeDB Cluster, a set of options is provided:
 Ranges are [inclusive, inclusive].
 
 | TypeDB Loader | TypeDB Driver (internal) |     TypeDB      | TypeDB Cluster  |
-|:-------------:|:----------------------:|:---------------:|:---------------:|
-|     1.8.0     |        2.24.15         |    2.24.x -     |    2.24.x -     |
-|     1.7.0     |         2.18.1         |  2.18.x 2.23.x  |  2.18.x 2.23.x  |
-|     1.6.0     |         2.14.2         | 2.14.x - 2.17.x | 2.14.x - 2.16.x |
-| 1.2.0 - 1.5.x |     2.8.0 - 2.14.0     | 2.8.0 - 2.14.0  |       N/A       |
-| 1.1.0 - 1.1.x |         2.8.0          |      2.8.x      |       N/A       |
-|     1.0.0     |     2.5.0 - 2.7.1      |  2.5.x - 2.7.x  |       N/A       |
-|     0.1.1     |     2.0.0 - 2.4.x      |  2.0.x - 2.4.x  |       N/A       |
-|     <0.1      |         1.8.0          |      1.8.x      |       N/A       |
+|:-------------:|:------------------------:|:---------------:|:---------------:|
+|     1.9.0     |          2.25.6          |    2.25.x -     |    2.25.x -     |
+|     1.8.0     |         2.24.15          |     2.24.x      |     2.24.x      |
+|     1.7.0     |          2.18.1          |  2.18.x 2.23.x  |  2.18.x 2.23.x  |
+|     1.6.0     |          2.14.2          | 2.14.x - 2.17.x | 2.14.x - 2.16.x |
+| 1.2.0 - 1.5.x |      2.8.0 - 2.14.0      | 2.8.0 - 2.14.0  |       N/A       |
+| 1.1.0 - 1.1.x |          2.8.0           |      2.8.x      |       N/A       |
+|     1.0.0     |      2.5.0 - 2.7.1       |  2.5.x - 2.7.x  |       N/A       |
+|     0.1.1     |      2.0.0 - 2.4.x       |  2.0.x - 2.4.x  |       N/A       |
+|     <0.1      |          1.8.0           |      1.8.x      |       N/A       |
 
 * [Type DB](https://github.com/vaticle/typedb)
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.vaticle.typedb-osi'
-version '1.8.0'
+version '1.9.0'
 
 repositories {
     mavenCentral()
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.vaticle.typedb:typedb-driver:2.25.2")
+    implementation("com.vaticle.typedb:typedb-driver:2.25.6")
     implementation("com.vaticle.typeql:typeql-lang:2.25.0")
     implementation("com.google.code.gson:gson:2.8.6")
     implementation("org.slf4j:slf4j-api:1.7.25")

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.vaticle.typedb-osi'
-version '1.7.0'
+version '1.8.0'
 
 repositories {
     mavenCentral()
@@ -15,8 +15,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.vaticle.typedb:typedb-client:2.18.1")
-    implementation("com.vaticle.typeql:typeql-lang:2.18.0")
+    implementation("com.vaticle.typedb:typedb-driver:2.25.2")
+    implementation("com.vaticle.typeql:typeql-lang:2.25.0")
     implementation("com.google.code.gson:gson:2.8.6")
     implementation("org.slf4j:slf4j-api:1.7.25")
     implementation("org.apache.logging.log4j:log4j-api:2.17.1")

--- a/src/main/java/com/vaticle/typedb/osi/loader/config/Configuration.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/config/Configuration.java
@@ -16,9 +16,9 @@
 
 package com.vaticle.typedb.osi.loader.config;
 
-import com.vaticle.typedb.client.api.TypeDBSession;
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.api.answer.ConceptMap;
+import com.vaticle.typedb.driver.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.answer.ConceptMap;
 import com.vaticle.typedb.osi.loader.type.AttributeValueType;
 import com.vaticle.typeql.lang.TypeQL;
 
@@ -39,7 +39,7 @@ public class Configuration {
     public static AttributeValueType getValueType(TypeDBSession session, String conceptType) {
         AttributeValueType valueType = null;
         try (TypeDBTransaction txn = session.transaction(TypeDBTransaction.Type.READ)) {
-            Set<ConceptMap> answers = txn.query().match(TypeQL.match(TypeQL.cVar("t").type(conceptType)).get(TypeQL.cVar("t"))).collect(Collectors.toSet());
+            Set<ConceptMap> answers = txn.query().get(TypeQL.match(TypeQL.cVar("t").type(conceptType)).get(TypeQL.cVar("t"))).collect(Collectors.toSet());
             assert answers.size() == 1;
             for (ConceptMap answer : answers) {
                 valueType = AttributeValueType.valueOf(answer.get("t").asAttributeType().getValueType().name());

--- a/src/main/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeGenerator.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeGenerator.java
@@ -16,18 +16,18 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.api.answer.ConceptMap;
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.answer.ConceptMap;
+import com.vaticle.typedb.driver.common.exception.TypeDBDriverException;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.io.FileLogger;
 import com.vaticle.typedb.osi.loader.util.GeneratorUtil;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
 import com.vaticle.typeql.lang.TypeQL;
+import com.vaticle.typeql.lang.builder.ConceptVariableBuilder;
 import com.vaticle.typeql.lang.pattern.constraint.ThingConstraint;
-import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
-import com.vaticle.typeql.lang.pattern.variable.UnboundConceptVariable;
+import com.vaticle.typeql.lang.pattern.statement.ThingStatement;
 import com.vaticle.typeql.lang.query.TypeQLInsert;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
@@ -75,7 +75,7 @@ public class AppendAttributeGenerator implements Generator {
                 } else {
                     safeInsert(tx, query, answers, allowMultiInsert, filePath, originalRow, dataLogger);
                 }
-            } catch (TypeDBClientException typeDBClientException) {
+            } catch (TypeDBDriverException typeDBDriverException) {
                 FileLogger.getLogger().logUnavailable(fileName, originalRow);
                 dataLogger.error("TypeDB Unavailable - Row in <" + filePath + "> not inserted - written to <" + fileNoExtension + "_unavailable.log" + ">");
             }
@@ -87,7 +87,7 @@ public class AppendAttributeGenerator implements Generator {
 
     public TypeQLInsert generateMatchInsertStatement(String[] row) {
         if (row.length > 0) {
-            ThingVariable.Thing entityMatchStatement = TypeQL.cVar("thing")
+            ThingStatement.Thing entityMatchStatement = TypeQL.cVar("thing")
                     .isa(appendConfiguration.getMatch().getType());
             for (Configuration.Definition.Attribute consAtt : appendConfiguration.getMatch().getOwnerships()) {
                 ArrayList<ThingConstraint.Predicate> constraintValues = GeneratorUtil.generateValueConstraintsConstrainingAttribute(
@@ -97,8 +97,8 @@ public class AppendAttributeGenerator implements Generator {
                 }
             }
 
-            UnboundConceptVariable insertUnboundVar = TypeQL.cVar("thing");
-            ThingVariable.Thing insertStatement = null;
+            ConceptVariableBuilder insertUnboundVar = TypeQL.cVar("thing");
+            ThingStatement.Thing insertStatement = null;
             for (Configuration.Definition.Attribute attributeToAppend : appendConfiguration.getInsert().getOwnerships()) {
                 ArrayList<ThingConstraint.Predicate> constraintValues = GeneratorUtil.generateValueConstraintsConstrainingAttribute(
                         row, header, filePath, fileSeparator, attributeToAppend);

--- a/src/main/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeOrInsertThingGenerator.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeOrInsertThingGenerator.java
@@ -16,18 +16,18 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.api.answer.ConceptMap;
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.answer.ConceptMap;
+import com.vaticle.typedb.driver.common.exception.TypeDBDriverException;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.io.FileLogger;
 import com.vaticle.typedb.osi.loader.util.GeneratorUtil;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
 import com.vaticle.typeql.lang.TypeQL;
+import com.vaticle.typeql.lang.builder.ConceptVariableBuilder;
 import com.vaticle.typeql.lang.pattern.constraint.ThingConstraint;
-import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
-import com.vaticle.typeql.lang.pattern.variable.UnboundConceptVariable;
+import com.vaticle.typeql.lang.pattern.statement.ThingStatement;
 import com.vaticle.typeql.lang.query.TypeQLInsert;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
@@ -81,7 +81,7 @@ public class AppendAttributeOrInsertThingGenerator implements Generator {
                 } else {
                     safeInsert(tx, appendQuery, answers, allowMultiInsert, filePath, originalRow, dataLogger);
                 }
-            } catch (TypeDBClientException typeDBClientException) {
+            } catch (TypeDBDriverException typeDBDriverException) {
                 FileLogger.getLogger().logUnavailable(fileName, originalRow);
                 dataLogger.error("TypeDB Unavailable - Row in <" + filePath + "> not inserted - written to <" + fileNoExtension + "_unavailable.log" + ">");
             }
@@ -97,7 +97,7 @@ public class AppendAttributeOrInsertThingGenerator implements Generator {
 
     public TypeQLInsert generateMatchInsertStatement(String[] row) {
         if (row.length > 0) {
-            ThingVariable.Thing entityMatchStatement = TypeQL.cVar("thing")
+            ThingStatement.Thing entityMatchStatement = TypeQL.cVar("thing")
                     .isa(appendOrInsertConfiguration.getMatch().getType());
             for (Configuration.Definition.Attribute ownershipThingGetter : appendOrInsertConfiguration.getMatch().getOwnerships()) {
                 ArrayList<ThingConstraint.Predicate> constraintValues = GeneratorUtil.generateValueConstraintsConstrainingAttribute(
@@ -107,8 +107,8 @@ public class AppendAttributeOrInsertThingGenerator implements Generator {
                 }
             }
 
-            UnboundConceptVariable insertUnboundVar = TypeQL.cVar("thing");
-            ThingVariable.Thing insertStatement = null;
+            ConceptVariableBuilder insertUnboundVar = TypeQL.cVar("thing");
+            ThingStatement.Thing insertStatement = null;
             for (Configuration.Definition.Attribute attributeToAppend : appendOrInsertConfiguration.getInsert().getOwnerships()) {
                 ArrayList<ThingConstraint.Predicate> constraintValues = GeneratorUtil.generateValueConstraintsConstrainingAttribute(
                         row, header, filePath, fileSeparator, attributeToAppend);
@@ -133,7 +133,7 @@ public class AppendAttributeOrInsertThingGenerator implements Generator {
 
     public TypeQLInsert generateThingInsertStatement(String[] row) {
         if (row.length > 0) {
-            ThingVariable.Thing insertStatement = GeneratorUtil.generateBoundThingVar(appendOrInsertConfiguration.getMatch().getType());
+            ThingStatement.Thing insertStatement = GeneratorUtil.generateBoundThingVar(appendOrInsertConfiguration.getMatch().getType());
 
             for (Configuration.Definition.Attribute attribute : appendOrInsertConfiguration.getMatch().getOwnerships()) {
                 ArrayList<ThingConstraint.Predicate> constraintValues = GeneratorUtil.generateValueConstraintsConstrainingAttribute(

--- a/src/main/java/com/vaticle/typedb/osi/loader/generator/AttributeGenerator.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/generator/AttributeGenerator.java
@@ -16,8 +16,8 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.common.exception.TypeDBDriverException;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.io.FileLogger;
 import com.vaticle.typedb.osi.loader.util.GeneratorUtil;
@@ -63,7 +63,7 @@ public class AttributeGenerator implements Generator {
             if (isValid(statement)) {
                 try {
                     tx.query().insert(statement);
-                } catch (TypeDBClientException clientException) {
+                } catch (TypeDBDriverException driverException) {
                     FileLogger.getLogger().logUnavailable(fileName, originalRow);
                     dataLogger.error("TypeDB Unavailable - Row in <" + filePath + "> not inserted - written to <" + fileNoExtension + "_unavailable.log" + ">");
                 }

--- a/src/main/java/com/vaticle/typedb/osi/loader/generator/EntityGenerator.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/generator/EntityGenerator.java
@@ -16,15 +16,15 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.common.exception.TypeDBDriverException;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.io.FileLogger;
 import com.vaticle.typedb.osi.loader.util.GeneratorUtil;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
 import com.vaticle.typeql.lang.TypeQL;
-import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
+import com.vaticle.typeql.lang.pattern.statement.ThingStatement;
 import com.vaticle.typeql.lang.query.TypeQLInsert;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
@@ -61,7 +61,7 @@ public class EntityGenerator implements Generator {
         if (valid(query)) {
             try {
                 tx.query().insert(query);
-            } catch (TypeDBClientException typeDBClientException) {
+            } catch (TypeDBDriverException typeDBDriverException) {
                 FileLogger.getLogger().logUnavailable(fileName, originalRow);
                 dataLogger.error("TypeDB Unavailable - Row in <" + filePath + "> not inserted - written to <" + fileNoExtension + "_unavailable.log" + ">");
             }
@@ -73,7 +73,7 @@ public class EntityGenerator implements Generator {
 
     public TypeQLInsert generateThingInsertStatement(String[] row) {
         if (row.length > 0) {
-            ThingVariable.Thing insertStatement = GeneratorUtil.generateBoundThingVar(entityConfiguration.getInsert().getEntity());
+            ThingStatement insertStatement = GeneratorUtil.generateBoundThingVar(entityConfiguration.getInsert().getEntity());
 
             GeneratorUtil.constrainThingWithHasAttributes(row, header, filePath, fileSeparator, insertStatement, entityConfiguration.getInsert().getOwnerships());
 

--- a/src/main/java/com/vaticle/typedb/osi/loader/generator/Generator.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/generator/Generator.java
@@ -16,7 +16,7 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
 
 public interface Generator {
     void write(TypeDBTransaction tx, String[] row, boolean allowMultiInsert);

--- a/src/main/java/com/vaticle/typedb/osi/loader/loader/AsyncLoaderWorker.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/loader/AsyncLoaderWorker.java
@@ -16,9 +16,9 @@
 
 package com.vaticle.typedb.osi.loader.loader;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
-import com.vaticle.typedb.client.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.common.concurrent.NamedThreadFactory;
 import com.vaticle.typedb.osi.loader.cli.LoadOptions;
@@ -75,7 +75,7 @@ public class AsyncLoaderWorker {
         this.status = Status.OK;
     }
 
-    public void run(TypeDBClient client) throws IOException, InterruptedException {
+    public void run(TypeDBDriver driver) throws IOException, InterruptedException {
 
         ArrayList<String> orderedBeforeGenerators = dc.getGlobalConfig().getOrderedBeforeGenerators();
         if (orderedBeforeGenerators == null) orderedBeforeGenerators = new ArrayList<>();
@@ -91,7 +91,7 @@ public class AsyncLoaderWorker {
         separateGenerators.addAll(orderedAfterGenerators);
         separateGenerators.addAll(ignoreGenerators);
 
-        try (TypeDBSession session = TypeDBUtil.getDataSession(client, databaseName)) {
+        try (TypeDBSession session = TypeDBUtil.getDataSession(driver, databaseName)) {
 
             //Load OrderBefore things...
             Util.info("loading ordered before things");

--- a/src/main/java/com/vaticle/typedb/osi/loader/util/GeneratorUtil.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/util/GeneratorUtil.java
@@ -24,7 +24,7 @@ import com.vaticle.typeql.lang.TypeQL;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 import com.vaticle.typeql.lang.pattern.constraint.Predicate;
 import com.vaticle.typeql.lang.pattern.constraint.ThingConstraint;
-import com.vaticle.typeql.lang.pattern.variable.ThingVariable;
+import com.vaticle.typeql.lang.pattern.statement.ThingStatement;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,7 +53,7 @@ public class GeneratorUtil {
                                                        String[] header,
                                                        String filePath,
                                                        char fileSeparator,
-                                                       ThingVariable<?> insertStatement,
+                                                       ThingStatement insertStatement,
                                                        Configuration.Definition.Attribute[] attributes) {
         for (Configuration.Definition.Attribute attribute : attributes) {
             ArrayList<ThingConstraint.Predicate> constraintValues = GeneratorUtil.generateValueConstraintsConstrainingAttribute(
@@ -68,7 +68,7 @@ public class GeneratorUtil {
         return Arrays.asList(header).indexOf(column);
     }
 
-    public static ThingVariable.Thing generateBoundThingVar(String schemaType) {
+    public static ThingStatement.Thing generateBoundThingVar(String schemaType) {
         return TypeQL.cVar("e").isa(schemaType);
     }
 

--- a/src/main/java/com/vaticle/typedb/osi/loader/util/Util.java
+++ b/src/main/java/com/vaticle/typedb/osi/loader/util/Util.java
@@ -16,9 +16,9 @@
 
 package com.vaticle.typedb.osi.loader.util;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.google.gson.reflect.TypeToken;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;

--- a/src/test/java/com/vaticle/typedb/osi/loader/cli/TypeDBLoaderCLITest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/cli/TypeDBLoaderCLITest.java
@@ -16,9 +16,9 @@
 
 package com.vaticle.typedb.osi.loader.cli;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
-import com.vaticle.typedb.client.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
 import com.vaticle.typedb.osi.loader.loader.TypeDBLoader;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typeql.lang.TypeQL;
@@ -115,13 +115,13 @@ public class TypeDBLoaderCLITest {
 
     private void clearData(String uri, String db) {
         System.out.println("Cleaning all previous loaded data in: " + db);
-        TypeDBClient client = TypeDBUtil.getCoreClient(uri);
-        try (TypeDBSession session = TypeDBUtil.getDataSession(client, db)) {
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver(uri);
+        try (TypeDBSession session = TypeDBUtil.getDataSession(driver, db)) {
             try (TypeDBTransaction txn = session.transaction(TypeDBTransaction.Type.WRITE)) {
                 txn.query().delete(TypeQL.parseQuery("match $x isa thing; delete $x isa thing;").asDelete());
                 txn.commit();
             }
         }
-        client.close();
+        driver.close();
     }
 }

--- a/src/test/java/com/vaticle/typedb/osi/loader/config/ConfigurationValidationTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/config/ConfigurationValidationTest.java
@@ -17,8 +17,8 @@
 
 package com.vaticle.typedb.osi.loader.config;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
 import org.apache.logging.log4j.LogManager;
@@ -86,7 +86,7 @@ public class ConfigurationValidationTest {
         Configuration dc = Util.initializeConfig(new File("src/test/resources/generic/configValidationTest.json").getAbsolutePath());
         assert dc != null;
 
-        TypeDBClient schemaClient = TypeDBUtil.getCoreClient(typedbURI, Runtime.getRuntime().availableProcessors());
+        TypeDBDriver schemaDriver = TypeDBUtil.getCoreDriver(typedbURI);
 
         ConfigurationValidation cv = new ConfigurationValidation(dc);
 
@@ -98,13 +98,13 @@ public class ConfigurationValidationTest {
 
         cv.validateSchemaPresent(validationReport);
         if (validationReport.get("errors").size() == 0) {
-            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaClient, databaseName, dc.getGlobalConfig().getSchema());
+            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaDriver, databaseName, dc.getGlobalConfig().getSchema());
             appLogger.info("cleaned database and migrated schema...");
         }
-        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaClient, databaseName);
+        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaDriver, databaseName);
         cv.validateConfiguration(validationReport, schemaSession);
         schemaSession.close();
-        schemaClient.close();
+        schemaDriver.close();
         validationReport.get("warnings").forEach(appLogger::warn);
         validationReport.get("errors").forEach(appLogger::error);
 
@@ -118,7 +118,7 @@ public class ConfigurationValidationTest {
         Configuration dc = Util.initializeConfig(new File("src/test/resources/phoneCalls/configValidationTest.json").getAbsolutePath());
         assert dc != null;
 
-        TypeDBClient schemaClient = TypeDBUtil.getCoreClient(typedbURI, Runtime.getRuntime().availableProcessors());
+        TypeDBDriver schemaDriver = TypeDBUtil.getCoreDriver(typedbURI);
 
         ConfigurationValidation cv = new ConfigurationValidation(dc);
 
@@ -130,13 +130,13 @@ public class ConfigurationValidationTest {
 
         cv.validateSchemaPresent(validationReport);
         if (validationReport.get("errors").size() == 0) {
-            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaClient, databaseName, dc.getGlobalConfig().getSchema());
+            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaDriver, databaseName, dc.getGlobalConfig().getSchema());
             appLogger.info("cleaned database and migrated schema...");
         }
-        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaClient, databaseName);
+        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaDriver, databaseName);
         cv.validateConfiguration(validationReport, schemaSession);
         schemaSession.close();
-        schemaClient.close();
+        schemaDriver.close();
         validationReport.get("warnings").forEach(appLogger::warn);
         validationReport.get("errors").forEach(appLogger::error);
 
@@ -147,7 +147,7 @@ public class ConfigurationValidationTest {
     public void validateDataConfig() {
         Configuration dc = Util.initializeConfig(new File("src/test/resources/generic/config.json").getAbsolutePath());
         assert dc != null;
-        TypeDBClient schemaClient = TypeDBUtil.getCoreClient(typedbURI, Runtime.getRuntime().availableProcessors());
+        TypeDBDriver schemaDriver = TypeDBUtil.getCoreDriver(typedbURI);
 
         ConfigurationValidation cv = new ConfigurationValidation(dc);
 
@@ -159,14 +159,14 @@ public class ConfigurationValidationTest {
         cv.validateSchemaPresent(validationReport);
 
         if (validationReport.get("errors").size() == 0) {
-            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaClient, databaseName, dc.getGlobalConfig().getSchema());
+            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaDriver, databaseName, dc.getGlobalConfig().getSchema());
             appLogger.info("cleaned database and migrated schema...");
         }
 
-        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaClient, databaseName);
+        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaDriver, databaseName);
         cv.validateConfiguration(validationReport, schemaSession);
         schemaSession.close();
-        schemaClient.close();
+        schemaDriver.close();
 
         validationReport.get("warnings").forEach(appLogger::warn);
         validationReport.get("errors").forEach(appLogger::error);
@@ -179,7 +179,7 @@ public class ConfigurationValidationTest {
         Configuration dc = Util.initializeConfig(new File("src/test/resources/phoneCalls/config.json").getAbsolutePath());
         assert dc != null;
 
-        TypeDBClient schemaClient = TypeDBUtil.getCoreClient(typedbURI, Runtime.getRuntime().availableProcessors());
+        TypeDBDriver schemaDriver = TypeDBUtil.getCoreDriver(typedbURI);
         ConfigurationValidation cv = new ConfigurationValidation(dc);
 
         HashMap<String, ArrayList<String>> validationReport = new HashMap<>();
@@ -189,14 +189,14 @@ public class ConfigurationValidationTest {
         validationReport.put("errors", errors);
         cv.validateSchemaPresent(validationReport);
         if (validationReport.get("errors").size() == 0) {
-            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaClient, databaseName, dc.getGlobalConfig().getSchema());
+            TypeDBUtil.cleanAndDefineSchemaToDatabase(schemaDriver, databaseName, dc.getGlobalConfig().getSchema());
             appLogger.info("cleaned database and migrated schema...");
         }
 
-        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaClient, databaseName);
+        TypeDBSession schemaSession = TypeDBUtil.getSchemaSession(schemaDriver, databaseName);
         cv.validateConfiguration(validationReport, schemaSession);
         schemaSession.close();
-        schemaClient.close();
+        schemaDriver.close();
 
         validationReport.get("warnings").forEach(appLogger::warn);
         validationReport.get("errors").forEach(appLogger::error);

--- a/src/test/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeGeneratorTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeGeneratorTest.java
@@ -16,8 +16,8 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
@@ -39,14 +39,14 @@ public class AppendAttributeGeneratorTest {
     public void phoneCallsPersonTest() throws IOException {
         String dbName = "append-attribute-generator-test";
         String sp = new File("src/test/resources/phoneCalls/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dcp = new File("src/test/resources/phoneCalls/config.json").getAbsolutePath();
         Configuration dc = Util.initializeConfig(dcp);
         assert dc != null;
         ArrayList<String> appendKeys = new ArrayList<>(List.of("append-twitter", "append-fakebook", "append-call-rating"));
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         for (String appendkey : appendKeys) {
             Configuration.Definition.Attribute[] hasAttributes = dc.getAppendAttribute().get(appendkey).getInsert().getOwnerships();
             if (hasAttributes != null) {
@@ -58,7 +58,7 @@ public class AppendAttributeGeneratorTest {
             }
         }
         session.close();
-        client.close();
+        driver.close();
 
         testTwitter(dc, appendKeys);
         testFakebook(dc, appendKeys);

--- a/src/test/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeOrInsertThingGeneratorTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/generator/AppendAttributeOrInsertThingGeneratorTest.java
@@ -17,8 +17,8 @@
 package com.vaticle.typedb.osi.loader.generator;
 
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
@@ -40,14 +40,14 @@ public class AppendAttributeOrInsertThingGeneratorTest {
     public void phoneCallsPersonTest() throws IOException {
         String dbName = "append-or-insert-generator-test";
         String sp = new File("src/test/resources/phoneCalls/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dcp = new File("src/test/resources/phoneCalls/config.json").getAbsolutePath();
         Configuration dc = Util.initializeConfig(dcp);
         assert dc != null;
         ArrayList<String> appendOrInsertKeys = new ArrayList<>(List.of("append-or-insert-person"));
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         for (String appendOrInsertkey : appendOrInsertKeys) {
             if (dc.getAppendAttributeOrInsertThing().get(appendOrInsertkey).getInsert().getOwnerships() != null) {
                 Util.setConstrainingAttributeConceptType(dc.getAppendAttributeOrInsertThing().get(appendOrInsertkey).getInsert().getOwnerships(), session);
@@ -57,7 +57,7 @@ public class AppendAttributeOrInsertThingGeneratorTest {
             }
         }
         session.close();
-        client.close();
+        driver.close();
 
         testPerson(dc, appendOrInsertKeys);
     }

--- a/src/test/java/com/vaticle/typedb/osi/loader/generator/AttributeGeneratorTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/generator/AttributeGeneratorTest.java
@@ -16,8 +16,8 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
@@ -38,8 +38,8 @@ public class AttributeGeneratorTest {
     public void generateInsertStatementsTest() throws IOException {
         String dbName = "attribute-generator-test";
         String sp = new File("src/test/resources/phoneCalls/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dp = new File("src/test/resources/phoneCalls/is-in-use.csv").getAbsolutePath();
         String dcp = new File("src/test/resources/phoneCalls/config.json").getAbsolutePath();
@@ -50,10 +50,10 @@ public class AttributeGeneratorTest {
                 dc.getAttributes().get(attributeKey),
                 Objects.requireNonNullElseGet(dc.getAttributes().get(attributeKey).getConfig().getSeparator(), () -> dc.getGlobalConfig().getSeparator()));
 
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         dc.getAttributes().get(attributeKey).getInsert().setConceptValueType(session);
         session.close();
-        client.close();
+        driver.close();
 
         Iterator<String> iterator = Util.newBufferedReader(dp).lines().skip(1).iterator();
 

--- a/src/test/java/com/vaticle/typedb/osi/loader/generator/EntityGeneratorTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/generator/EntityGeneratorTest.java
@@ -16,8 +16,8 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
 import com.vaticle.typedb.osi.loader.util.Util;
@@ -39,21 +39,21 @@ public class EntityGeneratorTest {
     public void genericEntityTest() throws IOException {
         String dbName = "entity-generator-test";
         String sp = new File("src/test/resources/generic/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dcp = new File("src/test/resources/generic/config.json").getAbsolutePath();
         Configuration dc = Util.initializeConfig(dcp);
         assert dc != null;
         ArrayList<String> entityKeys = new ArrayList<>(List.of("entity1", "entity2", "entity3"));
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         for (String entityKey : entityKeys) {
             for (int idx = 0; idx < dc.getEntities().get(entityKey).getInsert().getOwnerships().length; idx++) {
                 setEntityHasAttributeConceptType(entityKey, idx, dc, session);
             }
         }
         session.close();
-        client.close();
+        driver.close();
 
         String dp = new File("src/test/resources/generic/entity1.tsv").getAbsolutePath();
         EntityGenerator gen = new EntityGenerator(dp,
@@ -204,15 +204,15 @@ public class EntityGeneratorTest {
     public void phoneCallsPersonTest() throws IOException {
         String dbName = "entity-generator-test";
         String sp = new File("src/test/resources/phoneCalls/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dp = new File("src/test/resources/phoneCalls/person.csv").getAbsolutePath();
         String dcp = new File("src/test/resources/phoneCalls/config.json").getAbsolutePath();
         Configuration dc = Util.initializeConfig(dcp);
         assert dc != null;
         String entityKey = "person";
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         for (int idx = 0; idx < dc.getEntities().get(entityKey).getInsert().getOwnerships().length; idx++) {
             setEntityHasAttributeConceptType(entityKey, idx, dc, session);
         }
@@ -221,7 +221,7 @@ public class EntityGeneratorTest {
                 Objects.requireNonNullElseGet(dc.getEntities().get(entityKey).getConfig().getSeparator(), () -> dc.getGlobalConfig().getSeparator()));
 
         session.close();
-        client.close();
+        driver.close();
 
         Iterator<String> iterator = Util.newBufferedReader(dp).lines().skip(1).iterator();
 

--- a/src/test/java/com/vaticle/typedb/osi/loader/generator/RelationGeneratorTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/generator/RelationGeneratorTest.java
@@ -16,8 +16,8 @@
 
 package com.vaticle.typedb.osi.loader.generator;
 
-import com.vaticle.typedb.client.api.TypeDBClient;
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBDriver;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 import com.vaticle.typedb.osi.loader.util.QueryUtilTest;
 import com.vaticle.typedb.osi.loader.util.TypeDBUtil;
@@ -41,14 +41,14 @@ public class RelationGeneratorTest {
 
         String dbName = "relation-generator-test";
         String sp = new File("src/test/resources/generic/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dcp = new File("src/test/resources/generic/config.json").getAbsolutePath();
         Configuration dc = Util.initializeConfig(dcp);
         assert dc != null;
         ArrayList<String> relationKeys = new ArrayList<>(List.of("rel1"));
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         for (String relationKey : relationKeys) {
             if (dc.getRelations().get(relationKey).getInsert().getOwnerships() != null) {
                 Configuration.Definition.Attribute[] hasAttributes = dc.getRelations().get(relationKey).getInsert().getOwnerships();
@@ -59,7 +59,7 @@ public class RelationGeneratorTest {
             }
         }
         session.close();
-        client.close();
+        driver.close();
 
         String dp = new File("src/test/resources/generic/rel1.tsv").getAbsolutePath();
         RelationGenerator gen = new RelationGenerator(dp,
@@ -264,14 +264,14 @@ public class RelationGeneratorTest {
     public void phoneCallsPersonTest() throws IOException {
         String dbName = "relation-generator-test";
         String sp = new File("src/test/resources/phoneCalls/schema.gql").getAbsolutePath();
-        TypeDBClient client = TypeDBUtil.getCoreClient("localhost:1729");
-        TypeDBUtil.cleanAndDefineSchemaToDatabase(client, dbName, sp);
+        TypeDBDriver driver = TypeDBUtil.getCoreDriver("localhost:1729");
+        TypeDBUtil.cleanAndDefineSchemaToDatabase(driver, dbName, sp);
 
         String dcp = new File("src/test/resources/phoneCalls/config.json").getAbsolutePath();
         Configuration dc = Util.initializeConfig(dcp);
         assert dc != null;
         ArrayList<String> relationKeys = new ArrayList<>(List.of("contract", "call", "in-use", "communication-channel", "communication-channel-pm"));
-        TypeDBSession session = TypeDBUtil.getDataSession(client, dbName);
+        TypeDBSession session = TypeDBUtil.getDataSession(driver, dbName);
         for (String relationKey : relationKeys) {
             if (dc.getRelations().get(relationKey).getInsert().getOwnerships() != null) {
                 Configuration.Definition.Attribute[] hasAttributes = dc.getRelations().get(relationKey).getInsert().getOwnerships();
@@ -289,7 +289,7 @@ public class RelationGeneratorTest {
             }
         }
         session.close();
-        client.close();
+        driver.close();
 
         testContracts(dc, relationKeys);
         testCalls(dc, relationKeys);

--- a/src/test/java/com/vaticle/typedb/osi/loader/util/QueryUtilTest.java
+++ b/src/test/java/com/vaticle/typedb/osi/loader/util/QueryUtilTest.java
@@ -16,7 +16,7 @@
 
 package com.vaticle.typedb.osi.loader.util;
 
-import com.vaticle.typedb.client.api.TypeDBSession;
+import com.vaticle.typedb.driver.api.TypeDBSession;
 import com.vaticle.typedb.osi.loader.config.Configuration;
 
 import java.time.LocalDate;


### PR DESCRIPTION
## What is the goal of this PR?

We update and plan a release supporting TypeDB 2.25.x using updated drivers.

## What are the changes implemented in this PR?

- Update the TypeDB Driver to 2.25.6
- Use updated TypeQL, which includes replacing TypeQLMatch with TypeQLGet queries, adding mandatory `get` clauses, and replacing Numerics with Values.